### PR TITLE
Poprawka pobierania województwa #226

### DIFF
--- a/tasks/downloadBdotTask.py
+++ b/tasks/downloadBdotTask.py
@@ -32,7 +32,7 @@ class DownloadBdotTask(QgsTask):
         data_format = data_format.strip().split()[0]
         zip_suffix = "zip"
         if upper:
-            zip_suffix = "ZIP"
+            zip_suffix = zip_suffix.upper()
         if level == 0:
             self.url = f"{prefix}Polska_{data_format}.{zip_suffix}"
         elif level == 1:


### PR DESCRIPTION
Dodano funkcjonalność, aby pobierało najpierw .zip a jeżeli nie pobrało się to .ZIP. Dodatkowo zauważyłem błąd logiczny - metoda run() zawsze zwracała True jeżeli jej użytkownik nie przerwał, o czym było wspomniane w Issue