### PR TITLE
Poprawka błędu pamięci #221

### DIFF
--- a/pobieracz_danych_gugik.py
+++ b/pobieracz_danych_gugik.py
@@ -527,7 +527,7 @@ class PobieraczDanychGugik:
                             orto.get('kolor') == self.dockwidget.orto_kolor_cmbbx.currentText()]
             if not (self.dockwidget.orto_crs_cmbbx.currentText() == 'wszystkie'):
                 ortoList = [orto for orto in ortoList if
-                            orto.get('ukladWspolrzednychPoziomych').split(":")[
+                            orto.get('ukladWspolrzednychPoziomych') and orto.get('ukladWspolrzednychPoziomych').split(":")[
                                 0] == self.dockwidget.orto_crs_cmbbx.currentText()]
             if self.dockwidget.orto_from_dateTimeEdit.date():
                 ortoList = [orto for orto in ortoList if

--- a/utils.py
+++ b/utils.py
@@ -55,7 +55,10 @@ def createPointsFromLineLayer(layer, density):
     points = []
     for feat in layer.getFeatures():
         geom = feat.geometry()
-        for point in geom.densifyByDistance(density).vertices():
+        if not geom or geom.isNull():
+            continue
+        densified_geom = geom.densifyByDistance(density)
+        for point in densified_geom.vertices():
             if point not in points:
                 points.append(point)
     return points


### PR DESCRIPTION
Błąd, który był opisany w Issue wskazywał na brak dostępu do obiektu. Najprawdopodobniej był to efekt odwołania się do nieistniejącej już wartości w pamięci RAM. 
Poprawka w pliku pobieracz_danych_gugik.py wprowadzona została, bo podczas pobierania dostawałem inny błąd odnaleziony dopiero po mojej poprawie. Czasami zwracało puste atrybuty obiektu i był problem gdy się do nich odwoływano.