### PR TITLE
usunięcie duplikatów sub_list

### DIFF
--- a/pobieracz_danych_gugik.py
+++ b/pobieracz_danych_gugik.py
@@ -745,8 +745,6 @@ class PobieraczDanychGugik:
             self.dockwidget.las_fromLayer_btn.setEnabled(False)
             for point in points:
                 sub_list = las_api.getLasListbyPoint1992(point, self.dockwidget.las_evrf2007_rdbtn.isChecked())
-                if sub_list:
-                    las_list.extend(sub_list)
                 las_list.extend(sub_list)
             self.filterLasListAndRunTask(las_list)
         else:


### PR DESCRIPTION
Fixes #245
usunięcie fragmentu powodującego dwukrotne wprowadzenie danych do sub_list. Wykonałem kilka testów:
- dla warstwy poligonowej gdzie poligony znajdowały się w miejscu braku dostępnych
- dla warstwy bez poligonów
- dla warstwy punktowej z punktami w miejscu braku danych
- dla warstwy bez punktów brak 'if' nie spowodował występowania błędów dlatego zdecydowałem się na pozbycie się tego fragmentu

Brak danych w sub_list nie spowodował otrzymania błędu więc można uznać, że 'if' nie jest konieczny.
extend() próbujący dodać pustą listę nie powoduje otrzymania błędów ani wprowadzenia nowego obiektu.