### PR TITLE
Zapewnienie obsługi requests oraz qgsnetworkaccessmanager #266

### DIFF
--- a/egib_api.py
+++ b/egib_api.py
@@ -1,16 +1,17 @@
 from qgis.utils import iface
-from .utils import MessageUtils, NetworkUtils
+from .utils import MessageUtils
+from .network.http_adapter import FallbackHttpAdapter
 from lxml import etree
 
 from .constants import EGIB_WFS_URL, TIMEOUT_MS 
 
 class EgibAPI:
     def __init__(self):
-        self.network_utils = NetworkUtils()
+        self.http_adapter = FallbackHttpAdapter()
 
     def getWfsDict(self, filter_name):
         data_dict = {}
-        is_success, content = self.network_utils.fetchContent(EGIB_WFS_URL, timeout_ms=TIMEOUT_MS * 2)
+        is_success, content = self.http_adapter.fetchContent(EGIB_WFS_URL, timeout_ms=TIMEOUT_MS * 2)
         if not is_success:
             MessageUtils.pushLogWarning(f"Błąd pobierania danych EGiB: {content}")
             MessageUtils.pushWarning(iface, 'Ostrzeżenie:', content)

--- a/network/http_adapter.py
+++ b/network/http_adapter.py
@@ -290,8 +290,8 @@ class FallbackHttpAdapter(BaseHttpAdapter):
     Klasa, która najpierw spróbuje QgisHttpAdapter, a jeśli się nie uda, to RequestsHttpAdapter
     '''
     def __init__(self, qgis_adapter=None, requests_adapter=None):
-        self.qgis_adapter = qgis_adapter or QgisHttpAdapter()
-        self.requests_adapter = requests_adapter or RequestsHttpAdapter()
+        self.qgis_adapter = QgisHttpAdapter()
+        self.requests_adapter = RequestsHttpAdapter()
         self.error_markers = ERROR_MARKERS
         self.transport_markers = TRANSPORT_MARKERS
     def _isFallbackNeeded(self, error_message):

--- a/network/http_adapter.py
+++ b/network/http_adapter.py
@@ -1,0 +1,340 @@
+import requests
+import json
+import os
+import ssl
+from functools import partial
+from requests.adapters import HTTPAdapter
+from qgis.core import QgsBlockingNetworkRequest, QgsNetworkAccessManager
+from qgis.PyQt.QtCore import QUrl, QUrlQuery, QEventLoop, QTimer, QT_VERSION_STR
+from qgis.PyQt.QtNetwork import QNetworkRequest, QNetworkReply, QNetworkAccessManager
+from ..constants import (
+    TIMEOUT_MS,
+    MAX_ATTEMPTS,
+    CANCEL_CHECK_MS,
+    QT_VER,
+    HTTP_ERROR_THRESHOLD,
+    DEFAULT_ENCODING,
+    NETWORK_ATTRS,
+    ERR_TIMEOUT,
+    ERR_NONE,
+    ERR_CANCELED,
+    REDIRECT_POLICY_NAME,
+    REDIRECT_POLICY_NO_LESS_SAFE,
+    DEFAULT_REDIRECT_POLICY,
+    MSG_FILE_WRITE_ERROR,
+    MSG_DOWNLOAD_CANCELED,
+    MSG_EMPTY_CONTENT,
+    MSG_JSON_DECODE_ERROR,
+    MSG_HTTP_ERROR,
+    MSG_TIMEOUT,
+    MSG_NETWORK_ERROR,
+    MSG_NO_CONNECTION,
+    TRANSPORT_MARKERS,
+    ERROR_MARKERS,
+)
+
+class SslContextHttpAdapter(HTTPAdapter):
+    def __init__(self, ssl_context=None, **kwargs):
+        self.ssl_context = ssl_context
+        super().__init__(**kwargs)
+
+    def init_poolmanager(self, connections, maxsize, block=False, **pool_kwargs):
+        if self.ssl_context is not None:
+            pool_kwargs["ssl_context"] = self.ssl_context
+        return super().init_poolmanager(connections, maxsize, block, **pool_kwargs)
+
+    def proxy_manager_for(self, proxy, **proxy_kwargs):
+        if self.ssl_context is not None:
+            proxy_kwargs["ssl_context"] = self.ssl_context
+        return super().proxy_manager_for(proxy, **proxy_kwargs)
+
+class BaseHttpAdapter:
+    '''
+    Klasa bazowa do pobierania tekstu/JSON/pliku
+    '''
+
+    def fetchJson(self, url, params=None, timeout_ms=TIMEOUT_MS):
+        is_success, result = self.fetchContent(url, params, timeout_ms)
+        if not is_success:
+            return False, result
+        try:
+            return True, json.loads(result)
+        except json.JSONDecodeError as e:
+            return False, MSG_JSON_DECODE_ERROR.format(str(e))
+
+    @staticmethod
+    def timeoutToSeconds(timeout_ms):
+        return max(timeout_ms / 1000.0, 0.001)
+
+
+class QgisHttpAdapter():
+    '''
+    Klasa do pobierania tekstu/JSON/pliku za pomocą QgsBlockingNetworkRequest
+    '''
+    def __init__(self):
+        self.manager = QNetworkAccessManager()
+        self.manager.setProxy(QgsNetworkAccessManager.instance().proxy())
+        self.isCompatibleQtVersion = self._isCompatibleQtVersion(QT_VERSION_STR, 6)
+
+    def _isCompatibleQtVersion(self, cur_version, tar_version):
+        return cur_version.startswith(QT_VER[tar_version])
+
+    def getAttributeEnum(self, attr_name):
+        """Pobiera atrybut QNetworkRequest"""
+        if self.isCompatibleQtVersion:
+            if hasattr(QNetworkRequest, 'Attribute'):
+                val = getattr(QNetworkRequest.Attribute, attr_name, None)
+                if val is not None:
+                    return val
+        return getattr(QNetworkRequest, attr_name, None)
+
+    def getErrorEnum(self, attr_name):
+        """Pobiera kod błędu QNetworkReply"""
+        if self.isCompatibleQtVersion:
+            if hasattr(QNetworkReply, 'NetworkError'):
+                val = getattr(QNetworkReply.NetworkError, attr_name, None)
+                if val is not None:
+                    return val
+        return getattr(QNetworkReply, attr_name, None)
+
+    def setAttributes(self, request, timeout_ms):
+        """Ustawia atrybuty zapytania"""
+        redirect_attr = self.getAttributeEnum(NETWORK_ATTRS['REDIRECT'])
+        if redirect_attr is not None:
+            redirect_policy_class = getattr(QNetworkRequest, REDIRECT_POLICY_NAME, QNetworkRequest)
+            redirect_policy = getattr(redirect_policy_class, REDIRECT_POLICY_NO_LESS_SAFE, DEFAULT_REDIRECT_POLICY)
+            request.setAttribute(redirect_attr, redirect_policy)
+        
+        timeout_attr = self.getAttributeEnum(NETWORK_ATTRS['TIMEOUT'])
+        if timeout_attr is not None:
+            request.setAttribute(timeout_attr, timeout_ms)
+
+    def handleReplyError(self, reply, url_str):
+        """Centralna obsługa błędów sieciowych i HTTP"""
+        
+        error_code = reply.error()
+        error_str = reply.errorString()
+        
+        status_attr = self.getAttributeEnum(NETWORK_ATTRS['HTTP_STATUS'])
+        reason_attr = self.getAttributeEnum(NETWORK_ATTRS['HTTP_REASON'])
+        timeout_err = self.getErrorEnum(ERR_TIMEOUT)
+
+        http_status = reply.attribute(status_attr)
+        http_reason = reply.attribute(reason_attr)
+        
+        if http_status and http_status >= HTTP_ERROR_THRESHOLD:
+            return False, MSG_HTTP_ERROR.format(http_status, http_reason)
+        
+        if error_code == timeout_err:
+            return False, MSG_TIMEOUT.format(url_str)
+            
+        return False, MSG_NETWORK_ERROR.format(error_str, url_str)
+
+    def hasErrorOccurred(self, reply):
+        """Sprawdza czy wystąpił błąd w odpowiedzi"""
+        no_error = self.getErrorEnum(ERR_NONE)
+        return reply.error() != no_error
+
+    def handleReadyRead(self, reply, file):
+        if reply.bytesAvailable() > 0:
+            file.write(reply.readAll().data())
+
+    def loopForCancel(self, obj, reply, event_loop):
+        cancel_timer = QTimer()
+        cancel_timer.timeout.connect(lambda: reply.abort() if (obj and obj.isCanceled()) else None)
+        cancel_timer.start(CANCEL_CHECK_MS)
+        
+        event_loop.exec()
+
+        cancel_timer.stop()
+
+    def finalizeDownload(self, reply, url):
+        if self.hasErrorOccurred(reply):
+            canceled_error = self.getErrorEnum(ERR_CANCELED)
+            if reply.error() == canceled_error:
+                reply.deleteLater()
+                return False, MSG_DOWNLOAD_CANCELED
+            
+            error_res = self.handleReplyError(reply, url)
+            reply.deleteLater()
+            return error_res
+
+        reply.deleteLater()
+        return True, True
+
+    def fetchContent(self, url, params=None, timeout_ms=TIMEOUT_MS):
+        q_url = QUrl(url)
+        if params:
+            query = QUrlQuery()
+            for key, value in params.items():
+                query.addQueryItem(str(key), str(value))
+            q_url.setQuery(query)
+            
+        request = QNetworkRequest(q_url)
+        self.setAttributes(request, timeout_ms)
+        
+        blocking_request = QgsBlockingNetworkRequest()
+        error_code = blocking_request.get(request)
+        reply_content = blocking_request.reply()
+        
+        if error_code != QgsBlockingNetworkRequest.NoError:
+            return self.handleReplyError(reply_content, url)
+
+        raw_data = reply_content.content()
+        if len(raw_data) == 0:
+            return False, MSG_EMPTY_CONTENT.format(url)
+            
+        try:
+            data = bytes(raw_data).decode(DEFAULT_ENCODING)
+            return True, data
+        except UnicodeDecodeError:
+            return True, f"BinaryData: {len(raw_data)} bytes"
+
+    def downloadFile(self, url, dest_path, obj=None, timeout_ms=TIMEOUT_MS):
+        request = QNetworkRequest(QUrl(url))
+        self.setAttributes(request, timeout_ms)
+
+        dest_dir = os.path.dirname(dest_path)
+        if dest_dir:
+            os.makedirs(dest_dir, exist_ok=True)
+
+        event_loop = QEventLoop()
+        reply = self.manager.get(request)
+        try:
+            with open(dest_path, 'wb') as f:
+                reply.readyRead.connect(partial(self.handleReadyRead, reply, f))
+                reply.finished.connect(event_loop.quit)
+
+                self.loopForCancel(obj, reply, event_loop)
+
+                if reply.bytesAvailable() > 0:
+                    f.write(reply.readAll().data())
+        except IOError as e:
+            return False, MSG_FILE_WRITE_ERROR.format(str(e))
+            
+        return self.finalizeDownload(reply, url)
+
+class RequestsHttpAdapter():
+    '''
+    Klasa do pobierania tekstu/JSON/pliku za pomocą requests
+    '''
+    def __init__(self):
+        self.manager = requests.Session()
+        ssl_context = self._buildRequestsSslContext()
+        self.manager.mount("https://", SslContextHttpAdapter(ssl_context=ssl_context))
+
+    def _buildRequestsSslContext(self):
+        """
+        Build SSL context for requests.
+        Enables legacy renegotiation only when OpenSSL exposes this switch.
+        """
+        context = ssl.create_default_context()
+        legacy_option = getattr(ssl, "OP_LEGACY_SERVER_CONNECT", None)
+        if legacy_option is not None:
+            context.options |= legacy_option
+        return context
+
+    def fetchContent(self, url, params=None, timeout_ms=TIMEOUT_MS):
+        timeout_seconds = BaseHttpAdapter.timeoutToSeconds(timeout_ms)
+        try:
+            response = self.manager.get(
+                url,
+                params=params,
+                timeout=timeout_seconds,
+                allow_redirects=True
+            )
+            if response.status_code >= HTTP_ERROR_THRESHOLD:
+                return False, MSG_HTTP_ERROR.format(response.status_code, response.reason)
+
+            if not response.content:
+                return False, MSG_EMPTY_CONTENT.format(url)
+
+            response.encoding = response.encoding or DEFAULT_ENCODING
+            return True, response.text
+        except requests.exceptions.Timeout:
+            return False, MSG_TIMEOUT.format(url)
+        except requests.exceptions.RequestException as e:
+            return False, MSG_NETWORK_ERROR.format(str(e), url)
+            
+    def downloadFile(self, url, dest_path, obj=None, timeout_ms=TIMEOUT_MS):
+        timeout_seconds = BaseHttpAdapter.timeoutToSeconds(timeout_ms)
+        dest_dir = os.path.dirname(dest_path)
+        if dest_dir:
+            os.makedirs(dest_dir, exist_ok=True)
+
+        try:
+            with self.manager.get(url, stream=True, timeout=timeout_seconds, allow_redirects=True) as response:
+                if response.status_code >= HTTP_ERROR_THRESHOLD:
+                    return False, MSG_HTTP_ERROR.format(response.status_code, response.reason)
+
+                with open(dest_path, 'wb') as f:
+                    for chunk in response.iter_content(chunk_size=8192):
+                        if obj and obj.isCanceled():
+                            f.close()
+                            if os.path.exists(dest_path):
+                                os.remove(dest_path)
+                            return False, MSG_DOWNLOAD_CANCELED
+                        if chunk:
+                            f.write(chunk)
+        except IOError as e:
+            return False, MSG_FILE_WRITE_ERROR.format(str(e))
+        except requests.exceptions.Timeout:
+            return False, MSG_TIMEOUT.format(url)
+        except requests.exceptions.RequestException as e:
+            return False, MSG_NETWORK_ERROR.format(str(e), url)
+
+        return True, True
+
+class FallbackHttpAdapter(BaseHttpAdapter):
+    '''
+    Klasa, która najpierw spróbuje QgisHttpAdapter, a jeśli się nie uda, to RequestsHttpAdapter
+    '''
+    def __init__(self, qgis_adapter=None, requests_adapter=None):
+        self.qgis_adapter = qgis_adapter or QgisHttpAdapter()
+        self.requests_adapter = requests_adapter or RequestsHttpAdapter()
+        self.error_markers = ERROR_MARKERS
+        self.transport_markers = TRANSPORT_MARKERS
+    def _isFallbackNeeded(self, error_message):
+        if not error_message:
+            return False
+
+        msg = str(error_message).lower()
+
+        # Nie przełączamy adaptera dla błędów biznesowych HTTP ani anulowania.
+        if self.error_markers[0] in msg or self.error_markers[1] in msg:
+            return False
+        if MSG_DOWNLOAD_CANCELED.lower() in msg:
+            return False
+
+        # Fallback dla najczęstszych problemów transportowych/SSL.
+        return any(marker in msg for marker in self.transport_markers)
+
+    def fetchContent(self, url, params=None, timeout_ms=TIMEOUT_MS):
+        is_success, result = self.qgis_adapter.fetchContent(url, params=params, timeout_ms=timeout_ms)
+        if is_success:
+            return True, result
+
+        if not self._isFallbackNeeded(result):
+            return False, result
+
+        return self.requests_adapter.fetchContent(url, params=params, timeout_ms=timeout_ms)
+
+    def downloadFile(self, url, dest_path, obj=None, timeout_ms=TIMEOUT_MS):
+        is_success, result = self.qgis_adapter.downloadFile(
+            url=url,
+            dest_path=dest_path,
+            obj=obj,
+            timeout_ms=timeout_ms
+        )
+        if is_success:
+            return True, result
+
+        if not self._isFallbackNeeded(result):
+            return False, result
+
+        return self.requests_adapter.downloadFile(
+            url=url,
+            dest_path=dest_path,
+            obj=obj,
+            timeout_ms=timeout_ms
+        )

--- a/tasks/downloadEgibExcelTask.py
+++ b/tasks/downloadEgibExcelTask.py
@@ -3,7 +3,8 @@ from qgis.core import (
 )
 
 from ..constants import EGIB_WMS_URL, EGIB_TERYT_MAPPING, TIMEOUT_MS
-from ..utils import MessageUtils, NetworkUtils, ServiceAPI
+from ..utils import MessageUtils, ServiceAPI
+from ..network.http_adapter import FallbackHttpAdapter
 
 class DownloadEgibExcelTask(QgsTask):
     """QgsTask pobierania zestawień zbiorczych EGiB"""
@@ -19,7 +20,7 @@ class DownloadEgibExcelTask(QgsTask):
         self.teryt_wojewodztwo = teryt_wojewodztwo
         self.iface = iface
         self.service_api = ServiceAPI()
-        self.network_utils = NetworkUtils()
+        self.http_adapter = FallbackHttpAdapter()
 
     def run(self):
         list_url = []
@@ -46,7 +47,7 @@ class DownloadEgibExcelTask(QgsTask):
         for url in list_url:
             if self.isCanceled():
                 return False
-            success_check, result_check = self.network_utils.fetchContent(url, timeout_ms=TIMEOUT_MS)
+            success_check, result_check = self.http_adapter.fetchContent(url, timeout_ms=TIMEOUT_MS)
             if not success_check:
                 MessageUtils.pushLogWarning(f"Błąd sprawdzania dostępności {url}: {result_check}. Pomijam.")
                 continue

--- a/tasks/downloadOsnowaTask.py
+++ b/tasks/downloadOsnowaTask.py
@@ -1,7 +1,8 @@
 from qgis.core import QgsTask, Qgis
 
 from ..constants import OSNOWA_WMS_URL, TIMEOUT_MS
-from ..utils import MessageUtils, NetworkUtils, ServiceAPI
+from ..utils import MessageUtils, ServiceAPI
+from ..network.http_adapter import FallbackHttpAdapter
 
 
 class DownloadOsnowaTask(QgsTask):
@@ -14,7 +15,7 @@ class DownloadOsnowaTask(QgsTask):
         self.typ = typ
         self.iface = iface
         self.service_api = ServiceAPI()
-        self.network_utils = NetworkUtils()
+        self.http_adapter = FallbackHttpAdapter()
 
     def run(self):
         MessageUtils.pushLogInfo(f'Rozpoczęto zadanie: "{self.description()}"')
@@ -24,7 +25,7 @@ class DownloadOsnowaTask(QgsTask):
                 
             if self.isCanceled():
                 return False
-            success_check, result_check = self.network_utils.fetchContent(url, timeout_ms=TIMEOUT_MS*2)
+            success_check, result_check = self.http_adapter.fetchContent(url, timeout_ms=TIMEOUT_MS*2)
 
             if not success_check:
                 MessageUtils.pushLogCritical(f'Błąd przy sprawdzaniu dostępności {url}: {result_check}')

--- a/tasks/downloadTrees3dTask.py
+++ b/tasks/downloadTrees3dTask.py
@@ -4,7 +4,8 @@ from qgis.PyQt.QtCore import pyqtSignal
 from qgis.utils import iface
 
 from ..constants import TREES3D_URL, TIMEOUT_MS
-from ..utils import MessageUtils, NetworkUtils, ServiceAPI
+from ..utils import MessageUtils, ServiceAPI
+from ..network.http_adapter import FallbackHttpAdapter
 
 class DownloadTrees3dTask(QgsTask):
     """QgsTask pobierania modeli 3D drzew"""
@@ -17,7 +18,7 @@ class DownloadTrees3dTask(QgsTask):
         self.result = None
         self.iface = iface
         self.service_api = ServiceAPI()
-        self.network_utils = NetworkUtils()
+        self.http_adapter = FallbackHttpAdapter()
 
     def run(self):
         trees_url = f'{TREES3D_URL}{self.teryt_powiat[:2]}/{self.teryt_powiat}.zip'
@@ -26,7 +27,7 @@ class DownloadTrees3dTask(QgsTask):
         if self.isCanceled():
             return False
 
-        success_check, result_check = self.network_utils.fetchContent(trees_url, timeout_ms=TIMEOUT_MS*3)
+        success_check, result_check = self.http_adapter.fetchContent(trees_url, timeout_ms=TIMEOUT_MS*3)
 
         if not success_check:
             MessageUtils.pushLogCritical(f'Błąd przy sprawdzaniu dostępności {trees_url}: {result_check}')

--- a/uldk.py
+++ b/uldk.py
@@ -1,17 +1,18 @@
-from .utils import MessageUtils, NetworkUtils
+from .utils import MessageUtils
+from .network.http_adapter import FallbackHttpAdapter
 from .constants import LOCAL_API_URL, GET_VOIVODESHIP_ENDPOINT, GET_COUNTY_ENDPOINT, GET_COMMUNE_ENDPOINT, TIMEOUT_MS
 
 
 class RegionFetch:
     def __init__(self):
-        self.network_utils = NetworkUtils()
+        self.http_adapter = FallbackHttpAdapter()
         self.wojewodztwoDict = self.getWojewodztwoDict()
 
     def fetchUnitDict(self, endpoint):
         unit_dict = {}
         url = f"{LOCAL_API_URL}{endpoint}"
         MessageUtils.pushLogInfo(f"Pobieranie danych z: {url}")
-        is_success, result = self.network_utils.fetchJson(url, timeout_ms=TIMEOUT_MS)
+        is_success, result = self.http_adapter.fetchJson(url, timeout_ms=TIMEOUT_MS)
         if not is_success:
             MessageUtils.pushLogWarning(result)
             return unit_dict

--- a/utils.py
+++ b/utils.py
@@ -42,6 +42,7 @@ from .constants import (
     MSG_NETWORK_ERROR,
     MSG_NO_CONNECTION
 )
+from .network.http_adapter import FallbackHttpAdapter
 from functools import partial
 import lxml.etree as ET
 
@@ -277,169 +278,19 @@ class MessageUtils:
             level=Qgis.Critical
         )
 
-class NetworkUtils:
-
-    def __init__(self):
-        self.manager = QNetworkAccessManager()
-        self.manager.setProxy(QgsNetworkAccessManager.instance().proxy())
-
-    def _handleReplyError(self, reply, url_str):
-        """Centralna obsługa błędów sieciowych i HTTP"""
-        
-        error_code = reply.error()
-        error_str = reply.errorString()
-        
-        status_attr = self._getAttributeEnum(NETWORK_ATTRS['HTTP_STATUS'])
-        reason_attr = self._getAttributeEnum(NETWORK_ATTRS['HTTP_REASON'])
-        timeout_err = self._getErrorEnum(ERR_TIMEOUT)
-
-        http_status = reply.attribute(status_attr)
-        http_reason = reply.attribute(reason_attr)
-        
-        if http_status and http_status >= HTTP_ERROR_THRESHOLD:
-            return False, MSG_HTTP_ERROR.format(http_status, http_reason)
-        
-        if error_code == timeout_err:
-            return False, MSG_TIMEOUT.format(url_str)
-            
-        return False, MSG_NETWORK_ERROR.format(error_str, url_str)
-
-    def _hasErrorOccurred(self, reply):
-        """Sprawdza czy wystąpił błąd w odpowiedzi"""
-        no_error = self._getErrorEnum(ERR_NONE)
-        return reply.error() != no_error
-
-    def _getAttributeEnum(self, attr_name):
-        """Pobiera atrybut QNetworkRequest"""
-        if VersionUtils.isCompatibleQtVersion(QT_VERSION_STR, 6):
-            if hasattr(QNetworkRequest, 'Attribute'):
-                val = getattr(QNetworkRequest.Attribute, attr_name, None)
-                if val is not None:
-                    return val
-        return getattr(QNetworkRequest, attr_name, None)
-
-    def _getErrorEnum(self, attr_name):
-        """Pobiera kod błędu QNetworkReply"""
-        if VersionUtils.isCompatibleQtVersion(QT_VERSION_STR, 6):
-            if hasattr(QNetworkReply, 'NetworkError'):
-                val = getattr(QNetworkReply.NetworkError, attr_name, None)
-                if val is not None:
-                    return val
-        return getattr(QNetworkReply, attr_name, None)
-
-    def _setAttributes(self, request, timeout_ms):
-        """Ustawia atrybuty zapytania"""
-        redirect_attr = self._getAttributeEnum(NETWORK_ATTRS['REDIRECT'])
-        if redirect_attr is not None:
-            redirect_policy_class = getattr(QNetworkRequest, REDIRECT_POLICY_NAME, QNetworkRequest)
-            redirect_policy = getattr(redirect_policy_class, REDIRECT_POLICY_NO_LESS_SAFE, DEFAULT_REDIRECT_POLICY)
-            request.setAttribute(redirect_attr, redirect_policy)
-        
-        timeout_attr = self._getAttributeEnum(NETWORK_ATTRS['TIMEOUT'])
-        if timeout_attr is not None:
-            request.setAttribute(timeout_attr, timeout_ms)
-            
-    def fetchContent(self, url, params=None, timeout_ms=TIMEOUT_MS):
-        q_url = QUrl(url)
-        if params:
-            query = QUrlQuery()
-            for key, value in params.items():
-                query.addQueryItem(str(key), str(value))
-            q_url.setQuery(query)
-            
-        request = QNetworkRequest(q_url)
-        self._setAttributes(request, timeout_ms)
-        
-        blocking_request = QgsBlockingNetworkRequest()
-        error_code = blocking_request.get(request)
-        reply_content = blocking_request.reply()
-        
-        if error_code != QgsBlockingNetworkRequest.NoError:
-            return self._handleReplyError(reply_content, url)
-
-        raw_data = reply_content.content()
-        if len(raw_data) == 0:
-            return False, MSG_EMPTY_CONTENT.format(url)
-            
-        try:
-            data = bytes(raw_data).decode(DEFAULT_ENCODING)
-            return True, data
-        except UnicodeDecodeError:
-            return True, f"BinaryData: {len(raw_data)} bytes"
-
-    def fetchJson(self, url, params=None, timeout_ms=TIMEOUT_MS):
-        is_success, result = self.fetchContent(url, params, timeout_ms)
-        if not is_success:
-            return False, result
-        try:
-            return True, json.loads(result)
-        except json.JSONDecodeError as e:
-            return False, MSG_JSON_DECODE_ERROR.format(str(e))
-  
-    def downloadFile(self, url, dest_path, obj=None, timeout_ms=TIMEOUT_MS):
-        request = QNetworkRequest(QUrl(url))
-        self._setAttributes(request, timeout_ms)
-
-        dest_dir = os.path.dirname(dest_path)
-        if dest_dir:
-            os.makedirs(dest_dir, exist_ok=True)
-
-        event_loop = QEventLoop()
-        reply = self.manager.get(request)
-        try:
-            with open(dest_path, 'wb') as f:
-                reply.readyRead.connect(partial(self._handleReadyRead, reply, f))
-                reply.finished.connect(event_loop.quit)
-
-                self._loopForCancel(obj, reply, event_loop)
-
-                if reply.bytesAvailable() > 0:
-                    f.write(reply.readAll().data())
-        except IOError as e:
-            return False, MSG_FILE_WRITE_ERROR.format(str(e))
-            
-        return self._finilizeDownload(reply, url)
-    
-    def _handleReadyRead(self, reply, file):
-        if reply.bytesAvailable() > 0:
-            file.write(reply.readAll().data())
-
-    def _loopForCancel(self, obj, reply, event_loop):
-        cancel_timer = QTimer()
-        cancel_timer.timeout.connect(lambda: reply.abort() if (obj and obj.isCanceled()) else None)
-        cancel_timer.start(CANCEL_CHECK_MS)
-        
-        event_loop.exec()
-
-        cancel_timer.stop()
-    
-    def _finilizeDownload(self, reply, url):
-        if self._hasErrorOccurred(reply):
-            canceled_error = self._getErrorEnum(ERR_CANCELED)
-            if reply.error() == canceled_error:
-                reply.deleteLater()
-                return False, MSG_DOWNLOAD_CANCELED
-            
-            error_res = self._handleReplyError(reply, url)
-            reply.deleteLater()
-            return error_res
-
-        reply.deleteLater()
-        return True, True
-
 class ServiceAPI:
     def __init__(self, parent=None):
         if parent:
             self.iface = parent.iface
         else:
             self.iface = None
-        self.network_utils = NetworkUtils()
+        self.http_adapter = FallbackHttpAdapter()
 
     def getRequest(self, params, url):
         attempt = 0
         while attempt <= MAX_ATTEMPTS:
             attempt += 1
-            is_success, result = self.network_utils.fetchContent(url, params=params, timeout_ms=TIMEOUT_MS * 2)
+            is_success, result = self.http_adapter.fetchContent(url, params=params, timeout_ms=TIMEOUT_MS * 2)
             if is_success:
                 return True, result
             time.sleep(2)
@@ -475,7 +326,7 @@ class ServiceAPI:
         path = os.path.join(destFolder, file_name)
         self.cleanupFile(path)
 
-        is_success, result = self.network_utils.downloadFile(url, path, obj=obj)
+        is_success, result = self.http_adapter.downloadFile(url, path, obj=obj)
         if is_success:
             FileUtils.openFile(destFolder)
             return True, True
@@ -539,7 +390,7 @@ class ServiceAPI:
 
     def checkInternetConnection(self):
         # próba połączenia z serwerem np. gugik
-        is_success, _ = self.network_utils.fetchContent(ULDK_URL, timeout_ms=TIMEOUT_MS)
+        is_success, _ = self.http_adapter.fetchContent(ULDK_URL, timeout_ms=TIMEOUT_MS)
         if not is_success and self.iface:
             MessageUtils.pushWarning(self.iface, MSG_NO_CONNECTION)
         return is_success

--- a/wfs/utils.py
+++ b/wfs/utils.py
@@ -1,7 +1,8 @@
 import re
 import xml.etree.ElementTree as ET
 from ..constants import TIMEOUT_MS, WFS_NAMESPACES, WFS_FILTER_KEYS, WFS_ATTRIBUTES, VALUE_ALL
-from ..utils import NetworkUtils, MessageUtils
+from ..utils import MessageUtils
+from ..network.http_adapter import FallbackHttpAdapter
 
 def getTypenamesFromWFS(wfsUrl):
     """Lista dostępnych warstw z usługi WFS"""
@@ -10,8 +11,8 @@ def getTypenamesFromWFS(wfsUrl):
         'SERVICE': 'WFS',
         'request': 'GetCapabilities',
     }
-    network_utils = NetworkUtils()
-    is_success, result = network_utils.fetchContent(wfsUrl, params=PARAMS, timeout_ms=TIMEOUT_MS * 2)
+    http_adapter = FallbackHttpAdapter()
+    is_success, result = http_adapter.fetchContent(wfsUrl, params=PARAMS, timeout_ms=TIMEOUT_MS * 2)
 
     if not is_success:
         return False, result

--- a/wfs/wfs_egib.py
+++ b/wfs/wfs_egib.py
@@ -4,7 +4,8 @@ from time import sleep
 from lxml import etree
 from lxml.etree import XMLSyntaxError
 from datetime import datetime
-from ..utils import NetworkUtils, ServiceAPI
+from ..utils import ServiceAPI
+from ..network.http_adapter import FallbackHttpAdapter
 from ..constants import (
     MIN_FILE_SIZE, 
     CAPABILITIES_FILE_NAME, 
@@ -20,7 +21,7 @@ class WfsEgib:
 
     def __init__(self):
         self.service_api = ServiceAPI()
-        self.network_utils = NetworkUtils()
+        self.http_adapter = FallbackHttpAdapter()
 
     def saveXml(self, folder, url, teryt, obj=None):
         """Zapisuje plik XML dla zapytania getCapabilities"""
@@ -30,7 +31,7 @@ class WfsEgib:
         
         path = os.path.join(folder, CAPABILITIES_FILE_NAME)
 
-        is_success, result = self.network_utils.downloadFile(url, path, obj=obj)
+        is_success, result = self.http_adapter.downloadFile(url, path, obj=obj)
         if not is_success:
             return f"Nieprawidłowe warstwy: \n\n - (teryt: {teryt}) {result}. URL: \n{url}"
             
@@ -103,7 +104,7 @@ class WfsEgib:
             error_reason = None
 
             try:
-                is_success, result = self.network_utils.downloadFile(url_gml, layer_path, obj=obj)
+                is_success, result = self.http_adapter.downloadFile(url_gml, layer_path, obj=obj)
                 if is_success: 
                     # Sprawdzenie rozmiaru
                     if os.path.exists(layer_path) and os.path.getsize(layer_path) <= MIN_FILE_SIZE:

--- a/wms/utils.py
+++ b/wms/utils.py
@@ -2,7 +2,8 @@ import re
 import xml.etree.ElementTree as ET
 
 from ..constants import TIMEOUT_MS, WMS_NAMESPACES
-from ..utils import FilterUtils, NetworkUtils
+from ..utils import FilterUtils
+from ..network.http_adapter import FallbackHttpAdapter
 
 expr = re.compile(r"\{{1}.*\}{1}")
 
@@ -13,8 +14,8 @@ def getQueryableLayersFromWMS(wmsUrl):
         'SERVICE': 'WMS',
         'request': 'GetCapabilities',
     }
-    network_utils = NetworkUtils()
-    is_success, result = network_utils.fetchContent(wmsUrl, params=PARAMS, timeout_ms=TIMEOUT_MS * 2)
+    http_adapter = FallbackHttpAdapter()
+    is_success, result = http_adapter.fetchContent(wmsUrl, params=PARAMS, timeout_ms=TIMEOUT_MS * 2)
 
     if not is_success:
         return False, result


### PR DESCRIPTION
- Przeniesienie logiki sieciowej do skryptu network\http_adapter.py
- Utworzenie klas, które odpowiadają za:
- QgisHttpAdapter: posiada metody zapewniające kompatybilność z qgsnetworkaccessmanager (kopia klasy NetworkUtils z utils.py)
- RequestsHttpAdapter: zapewnia kompatybilność z biblioteką requests (adekwatnie przepisane metody z klasy QgisHttpAdapter)
- BaseHttpAdapter: klasa przechowująca metody uniwersalne (używane zarówno przez QgisHttpAdapter jak i RequestsHttpAdapter)
- FallbackHttpAdapter: fallback - gdy nie zadziała QgisHttpAdapter - wykonuje metody z RequestsHttpAdapter
- SslContextHttpAdapter: dziedziczy po zewnętrznym requests.HttpAdapter - ustawia połączenie ssl i proxy
* funkcje z zewnętrznej biblioteki są napisane snake_case