### PR TITLE
Poprawka dla wersji 3.28 QGIS #279

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -51,13 +51,17 @@ from functools import partial
 import lxml.etree as ET
 
 try:
-    if urllib3.__version__.startswith('1.'):
+    if urllib3.__version__.startswith("1."):
         from urllib3.util.ssl_ import create_urllib3_context
     else:
         from urllib3.util import create_urllib3_context
 except ImportError:
-    QMessageBox.critical(None, "Błąd biblioteki", 
-                         "Wystąpił problem z wersją urllib3. Wtyczka może nie działać poprawnie.")
+    QMessageBox.critical(
+        None,
+        "Błąd biblioteki",
+        "Wystąpił problem z wersją urllib3. "
+        "Wtyczka może nie działać poprawnie.",
+    )
     create_urllib3_context = None
     
 

--- a/utils.py
+++ b/utils.py
@@ -49,10 +49,17 @@ from .constants import (
 )
 from functools import partial
 import lxml.etree as ET
+
 try:
-    from urllib3.util.ssl_ import create_urllib3_context
+    if urllib3.__version__.startswith('1.'):
+        from urllib3.util.ssl_ import create_urllib3_context
+    else:
+        from urllib3.util import create_urllib3_context
 except ImportError:
-    from urllib3.util import create_urllib3_context
+    QMessageBox.critical(None, "Błąd biblioteki", 
+                         "Wystąpił problem z wersją urllib3. Wtyczka może nie działać poprawnie.")
+    create_urllib3_context = None
+    
 
 class LegacySslAdapter(requests.adapters.HTTPAdapter):
     """Adapter dopuszczający stare połączenia SSL"""

--- a/utils.py
+++ b/utils.py
@@ -21,7 +21,6 @@ from qgis.PyQt.QtNetwork import QNetworkReply, QNetworkRequest, QNetworkAccessMa
 import requests
 import ssl
 import urllib3
-from urllib3.util import create_urllib3_context
 from .constants import (
     TIMEOUT_MS,
     MAX_ATTEMPTS,
@@ -50,6 +49,10 @@ from .constants import (
 )
 from functools import partial
 import lxml.etree as ET
+try:
+    from urllib3.util.ssl_ import create_urllib3_context
+except ImportError:
+    from urllib3.util import create_urllib3_context
 
 class LegacySslAdapter(requests.adapters.HTTPAdapter):
     """Adapter dopuszczający stare połączenia SSL"""


### PR DESCRIPTION
Wtyczka miała błędny import dla wersji 3.28. Błąd wynika ze zmian wprowadzonych podczas szybkiego fixu (wtedy gdy cała wtyczka nie mogła nic pobierać, co GUGiK zmienił wymagane certyfikaty). 
Dodaję Cię do review, żebyś wiedział co się dzieje i z czego to wynika. 